### PR TITLE
Update defaults.rb

### DIFF
--- a/lib/capistrano/laravel51/defaults.rb
+++ b/lib/capistrano/laravel51/defaults.rb
@@ -2,7 +2,7 @@ set :laravel_roles, :all
 set :laravel_artisan_flags, '--env=production'
 set :laravel_server_user, "deploy"
 
-set :linked_dirs, ['vendor', 'storage/app', 'storage/logs', 'storage/framework', 'bootstrap/cache']
+set :linked_dirs, ['vendor', 'storage', 'node_modules']
 
 set :file_permissions_paths, fetch(:linked_dirs)
 set :file_permissions_users, [fetch(:laravel_server_user)]


### PR DESCRIPTION
removed /bootstrap/cache from shared folders
include whole /storage path in shared folders
include /node_modules in shared folders